### PR TITLE
Single provider reporting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,4 +8,14 @@ DLTN Docs Generator
 -----
 About
 -----
-A simple utility to generate `technical documentation <https://dltn-technical-docs.readthedocs.io/en/latest/>`_ for the Digital Library of Tennessee.
+A simple utility to generate `technical documentation <https://dltn-technical-docs.readthedocs.io/en/latest/>`_ for the
+Digital Library of Tennessee.
+
+------------------
+Generating Reports
+------------------
+
+For instructions on generating reports, see:
+
+1. `Generating Provider Reports <https://dltn-technical-docs.readthedocs.io/en/latest/procedures/reporting.html>`_
+2. `Generating Quarterly Reports <https://dltn-technical-docs.readthedocs.io/en/latest/quarterly_harvests.html#generating-quarterly-reports>`_

--- a/docs/procedures/reporting.rst
+++ b/docs/procedures/reporting.rst
@@ -1,12 +1,27 @@
-=========
-Reporting
-=========
+===========================
+Generating Provider Reports
+===========================
 
-Individual provider reports are generated automatically based on data from:
+This section describes how to generate provider reports and things to know regarding this process.
+
+Individual provider reports are generated based on data from:
 
 * Repox with `pyrepox <https://github.com/markpbaggett/pyrepox>`_
 * `The DLTN MODS OAI Feed <https://dpla.lib.utk.edu/repox/OAIHandler?verb=ListRecords&metadataPrefix=MODS>`_
-* sets in DPLA ingest's `TN mapper <https://github.com/dpla/ingestion/blob/develop/profiles/tn.pjs>`_
 
-When this repository is updated, new versions of these reports are pushed automatically to `readthedocs <https://dltn-technical-docs.readthedocs.io/en/latest/index.html#current-providers>`_.
+**Before you generate:** If you just want to update an `email address`, `description`, or `oai_endpoint` for a provider,
+don't need to generate a whole new report.  Instead:
 
+1. update the information against the **Repox API** (you can do this with pyrepox)
+2. edit the corresponding rst directly.
+
+Doing this is much faster!  Just make sure you update the value in Repox and not just in the rst file.
+
+------------------
+Generating Reports
+------------------
+
+1. Fill out your `config file`.
+2. If you want MODS count to be correct, make sure that value is set to True (even though it takes a lot longer.)
+3. To generate for all providers, just run `python generate.py`
+4. To generate a report for a specific provider, use the p flag with the Repox provider_id:  `python generate.py -p memphispublicr0`

--- a/generate/generate.py
+++ b/generate/generate.py
@@ -34,17 +34,7 @@ class DLTN:
             )
         )
         for provider in tqdm(self.providers):
-            with open(
-                f"../docs/providers/{provider['id']}.rst", "w+"
-            ) as provider_rst_file:
-                provider_rst_file.write(f'{provider["name"]}\n')
-                provider_rst_file.write("=" * len(provider["name"]))
-                provider_rst_file.write(f"\n\nDetails\n-------\n\n")
-                provider_rst_file.write(self.__generate_details_section(provider))
-                provider_rst_file.write(f"\n\nDatasets\n--------\n\n")
-                provider_rst_file.write(
-                    self.__generate_dataset_details_section(provider["id"])
-                )
+            self._write_rst_file(provider)
         return
 
     def generate_rst_page_for_one_provider(self, provider_id):
@@ -56,17 +46,7 @@ class DLTN:
                         f"\n\n\t:snake: Generating documentation for {provider['name']}: :snake:\n"
                     )
                 )
-                with open(
-                            f"../docs/providers/{provider['id']}.rst", "w+"
-                    ) as provider_rst_file:
-                        provider_rst_file.write(f'{provider["name"]}\n')
-                        provider_rst_file.write("=" * len(provider["name"]))
-                        provider_rst_file.write(f"\n\nDetails\n-------\n\n")
-                        provider_rst_file.write(self.__generate_details_section(provider))
-                        provider_rst_file.write(f"\n\nDatasets\n--------\n\n")
-                        provider_rst_file.write(
-                            self.__generate_dataset_details_section(provider["id"])
-                        )
+                self._write_rst_file(provider)
         return
 
     @staticmethod
@@ -111,6 +91,18 @@ class DLTN:
             current_set = DataSet(dataset["dataSource"]["id"])
             dataset_details += f"{current_set.generate_rst_for_set()}\n\n"
         return dataset_details
+
+    def _write_rst_file(self, a_provider):
+        with open(f"../docs/providers/{a_provider['id']}.rst", "w+") as provider_rst_file:
+            provider_rst_file.write(f'{a_provider["name"]}\n')
+            provider_rst_file.write("=" * len(a_provider["name"]))
+            provider_rst_file.write(f"\n\nDetails\n-------\n\n")
+            provider_rst_file.write(self.__generate_details_section(a_provider))
+            provider_rst_file.write(f"\n\nDatasets\n--------\n\n")
+            provider_rst_file.write(
+                self.__generate_dataset_details_section(a_provider["id"])
+            )
+        return
 
 
 class DataSet:

--- a/generate/generate.py
+++ b/generate/generate.py
@@ -47,6 +47,28 @@ class DLTN:
                 )
         return
 
+    def generate_rst_page_for_one_provider(self, provider_id):
+        """Generate an rst page for one specific provider"""
+        for provider in tqdm(self.providers):
+            if provider_id == provider['id']:
+                print(
+                    emojize(
+                        f"\n\n\t:snake: Generating documentation for {provider['name']}: :snake:\n"
+                    )
+                )
+                with open(
+                            f"../docs/providers/{provider['id']}.rst", "w+"
+                    ) as provider_rst_file:
+                        provider_rst_file.write(f'{provider["name"]}\n')
+                        provider_rst_file.write("=" * len(provider["name"]))
+                        provider_rst_file.write(f"\n\nDetails\n-------\n\n")
+                        provider_rst_file.write(self.__generate_details_section(provider))
+                        provider_rst_file.write(f"\n\nDatasets\n--------\n\n")
+                        provider_rst_file.write(
+                            self.__generate_dataset_details_section(provider["id"])
+                        )
+        return
+
     @staticmethod
     def __generate_details_section(current_provider):
         """Generates top-level details section about the provider of provider rst files.
@@ -185,4 +207,5 @@ class OAIMODSCounter:
 
 
 if __name__ == "__main__":
-    DLTN("TNDPLAr0").generate_rst_page_for_each_provider()
+    #DLTN("TNDPLAr0").generate_rst_page_for_each_provider()
+    DLTN("TNDPLAr0").generate_rst_page_for_one_provider('memphispublicr0')

--- a/generate/generate.py
+++ b/generate/generate.py
@@ -5,6 +5,7 @@ from emoji import emojize
 import requests
 import arrow
 from lxml import etree
+import argparse
 
 settings = yaml.safe_load(open("../config.yml", "r"))
 repox_connection = Repox(settings["repox"], settings["username"], settings["password"])
@@ -199,5 +200,12 @@ class OAIMODSCounter:
 
 
 if __name__ == "__main__":
-    #DLTN("TNDPLAr0").generate_rst_page_for_each_provider()
-    DLTN("TNDPLAr0").generate_rst_page_for_one_provider('memphispublicr0')
+    parser = argparse.ArgumentParser(description="Generate Provider Reports for DLTN.")
+    parser.add_argument(
+        "-p", "--provider", dest="provider", required=False
+    )
+    args = parser.parse_args()
+    if args.provider:
+        DLTN("TNDPLAr0").generate_rst_page_for_one_provider(args.provider)
+    else:
+        DLTN("TNDPLAr0").generate_rst_page_for_each_provider()


### PR DESCRIPTION
This adds instructions and the ability to generate reports for a single provider.

Until this is merged, you can see the instructions in the reporting.rst file.